### PR TITLE
[FEAT] #99: 페이지 전환 애니메이션 방향 구분

### DIFF
--- a/frontend/src/components/pageAnimation/AnimationPresence.tsx
+++ b/frontend/src/components/pageAnimation/AnimationPresence.tsx
@@ -43,7 +43,17 @@ export default function AnimatePresence({ children }: IAnimatePresence) {
     return element.key;
   });
   const removedChildrenKey = new Set(prevKeys.filter((key) => !currentKeys.includes(key)));
-  const childrenToRender = validChildren.map((child) => cloneElement(child, { isVisible: true }));
+
+  /**
+   *  왼쪽 애니메이션? 오른쪽 애니메이션?
+   */
+  const isLeft = useRef(true);
+  if (prevKeys[0] && currentKeys[0] && removedChildrenKey.size) {
+    isLeft.current = parseInt(prevKeys[0]?.toString()) < parseInt(currentKeys[0].toString());
+  }
+  const childrenToRender = validChildren.map((child) =>
+    cloneElement(child, { isVisible: true, isLeft: isLeft.current })
+  );
 
   /**
    * isVisible 를 통해 사라질 컴포넌트 구분
@@ -63,7 +73,7 @@ export default function AnimatePresence({ children }: IAnimatePresence) {
     childrenToRender.splice(
       elementIndex,
       0,
-      cloneElement(element, { isVisible: false, onExitAnimationDone })
+      cloneElement(element, { isVisible: false, onExitAnimationDone, isLeft: isLeft.current })
     );
   });
 

--- a/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
+++ b/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
@@ -4,17 +4,22 @@ import { styled } from 'styled-components';
 export interface IDefaultPage {
   onExitAnimationDone?: () => void;
   isVisible?: boolean;
+  isLeft?: boolean | undefined;
 }
 
 interface IPageAnimationWrapper extends IDefaultPage, React.HTMLAttributes<HTMLDivElement> {}
 export default function PageAnimationWrapper({
   onExitAnimationDone,
   isVisible = true,
+  isLeft,
   children,
 }: IPageAnimationWrapper) {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const visibleAnimation = isLeft ? visibleLeftAnimation : visibleRightAnimation;
+    const unvisibleAnimation = isLeft ? unvisibleLeftAnimation : unvisibleRightAnimation;
+
     if (isVisible) {
       const animate = wrapperRef.current?.animate(
         visibleAnimation.keyframes,
@@ -31,7 +36,7 @@ export default function PageAnimationWrapper({
       animate?.finished.then(onExitAnimationDone).catch((err) => console.log(err));
       return () => animate?.cancel();
     }
-  }, [isVisible, onExitAnimationDone]);
+  }, [isVisible, onExitAnimationDone, isLeft]);
 
   return <Wrapper ref={wrapperRef}>{children}</Wrapper>;
 }
@@ -49,7 +54,7 @@ interface IAnimation {
   option: KeyframeAnimationOptions;
 }
 
-const visibleAnimation: IAnimation = {
+const visibleLeftAnimation: IAnimation = {
   keyframes: [
     { right: '-100%', opacity: 0 },
     { right: 0, opacity: 1 },
@@ -60,10 +65,33 @@ const visibleAnimation: IAnimation = {
   },
 };
 
-const unvisibleAnimation: IAnimation = {
+const unvisibleLeftAnimation: IAnimation = {
   keyframes: [
     { right: 0, opacity: 1 },
     { right: '100%', opacity: 0 },
+  ],
+  option: {
+    duration: 700,
+    easing: 'ease-out',
+    fill: 'forwards',
+  },
+};
+
+const visibleRightAnimation: IAnimation = {
+  keyframes: [
+    { left: '-100%', opacity: 0 },
+    { left: 0, opacity: 1 },
+  ],
+  option: {
+    duration: 700,
+    easing: 'ease-out',
+  },
+};
+
+const unvisibleRightAnimation: IAnimation = {
+  keyframes: [
+    { left: 0, opacity: 1 },
+    { left: '100%', opacity: 0 },
   ],
   option: {
     duration: 700,

--- a/frontend/src/components/router/CustomRouter.tsx
+++ b/frontend/src/components/router/CustomRouter.tsx
@@ -23,32 +23,32 @@ export default function CustomRouter() {
   return (
     <AnimatePresence>
       {pathname === PATH.trim && (
-        <PageAnimationWrapper key={'trim'}>
+        <PageAnimationWrapper key={0}>
           <TrimPage />
         </PageAnimationWrapper>
       )}
       {pathname === PATH.modelType && (
-        <PageAnimationWrapper key={'modelType'}>
+        <PageAnimationWrapper key={1}>
           <ModelTypePage />
         </PageAnimationWrapper>
       )}
       {pathname === PATH.exterior && (
-        <PageAnimationWrapper key={'exterior'}>
+        <PageAnimationWrapper key={2}>
           <ExteriorPage />
         </PageAnimationWrapper>
       )}
       {pathname === PATH.interior && (
-        <PageAnimationWrapper key={'interior'}>
+        <PageAnimationWrapper key={3}>
           <InteriorPage />
         </PageAnimationWrapper>
       )}
       {pathname === PATH.option && (
-        <PageAnimationWrapper key={'option'}>
+        <PageAnimationWrapper key={4}>
           <OptionPage />
         </PageAnimationWrapper>
       )}
       {pathname === PATH.result && (
-        <PageAnimationWrapper key={'result'}>
+        <PageAnimationWrapper key={5}>
           <ResultPage />
         </PageAnimationWrapper>
       )}


### PR DESCRIPTION
<!-- 리뷰어가 코드의 문맥을 빠르게 파악할 수 있도록 PR의 내용에서 충분한 정보를 전달해주세요!-->

<!-- 체크 해주세요. -->

- [ ] 버그 수정
- [x] 기능 개발
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 기타... 설명:

## 📝 설명

<!-- 어떤 작업 사항이 있는지 간략하게 설명해주세요. -->

- 좌 -> 우 애니메이션도 가능!


```tsx
// CustomRouter.tsx
<AnimatePresence>
      {pathname === PATH.trim && (
        <PageAnimationWrapper key={0}>
          <TrimPage />
        </PageAnimationWrapper>
      )}
     ...

      {pathname === PATH.option && (
        <PageAnimationWrapper key={4}>
          <OptionPage />
        </PageAnimationWrapper>
      )}
      {pathname === PATH.result && (
        <PageAnimationWrapper key={5}>
          <ResultPage />
        </PageAnimationWrapper>
      )}
    </AnimatePresence>

```
## ✨ 특이 사항

`key` 값 비교해서 좌 -> 우 , 우->좌 애니메이션 구분
<!-- 리뷰어에게 특정 사항을 전달할 내용이 있다면 여기에 작성해주세요. -->

## 🖼️ 스크린샷 (선택 사항)

https://github.com/softeerbootcamp-2nd/A2-CarTag/assets/77661228/56f32e42-5866-4a56-810e-feda4f18cef5


<!-- 변경 사항에 대한 스크린샷이 있다면 여기에 첨부해주세요. -->
