### PR TITLE
[FIX] #182: 첫 접속 페이지 애니메이션 제거

### DIFF
--- a/frontend/src/components/modal/CloseModal.tsx
+++ b/frontend/src/components/modal/CloseModal.tsx
@@ -5,7 +5,7 @@ import { flexCenterCss } from '../../utils/commonStyle';
 import RectButton from '../common/buttons/RectButton';
 import { HYUNDAI_URL } from '../../utils/constants';
 import { DimmedBackground } from './DimmedBackground';
-import { CloseModalContext } from '../../context/closeModalContext';
+import { CloseModalContext } from '../../context/CloseModalContext';
 
 interface ICloseModal extends HTMLAttributes<HTMLDivElement> {}
 

--- a/frontend/src/components/pageAnimation/AnimationPresence.tsx
+++ b/frontend/src/components/pageAnimation/AnimationPresence.tsx
@@ -23,7 +23,8 @@ export default function AnimatePresence({ children }: IAnimatePresence) {
   const childrenOfPreviousRender = useRef(validChildren);
   const elementByKey = useRef<IElementByKeyMap>(getElementByKeyMap(validChildren, {}));
   const [_, forceRender] = useState(0);
-
+  const isSamePage = childrenOfPreviousRender.current[0].key === validChildren[0].key;
+  const animatePresence = !isSamePage;
   /**
    * 렌더링이 끝난 이후, 렌더링 전의 컴포넌트를 참조하여 기억
    * elementByKey는 직전 렌더링과 직후 렌더링 되는 컴포넌트 기억
@@ -52,11 +53,12 @@ export default function AnimatePresence({ children }: IAnimatePresence) {
     isLeft.current = parseInt(prevKeys[0]?.toString()) < parseInt(currentKeys[0].toString());
   }
   const childrenToRender = validChildren.map((child) =>
-    cloneElement(child, { isVisible: true, isLeft: isLeft.current })
+    cloneElement(child, { isVisible: true, isLeft: isLeft.current, animation: animatePresence })
   );
 
   /**
-   * isVisible 를 통해 사라질 컴포넌트 구분
+   * isVisible 를 통
+   * 해 사라질 컴포넌트 구분
    */
   removedChildrenKey.forEach((removedKey) => {
     if (!removedKey) return;
@@ -73,7 +75,12 @@ export default function AnimatePresence({ children }: IAnimatePresence) {
     childrenToRender.splice(
       elementIndex,
       0,
-      cloneElement(element, { isVisible: false, onExitAnimationDone, isLeft: isLeft.current })
+      cloneElement(element, {
+        isVisible: false,
+        onExitAnimationDone,
+        isLeft: isLeft.current,
+        animation: true,
+      })
     );
   });
 

--- a/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
+++ b/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
@@ -41,7 +41,7 @@ export default function PageAnimationWrapper({
       animate?.finished.then(onExitAnimationDone).catch((err) => console.log(err));
       return () => animate?.cancel();
     }
-  }, [isVisible, onExitAnimationDone, isLeft]);
+  }, [isVisible, onExitAnimationDone, isLeft, animation]);
 
   return <Wrapper ref={wrapperRef}>{children}</Wrapper>;
 }

--- a/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
+++ b/frontend/src/components/pageAnimation/PageAnimationWrapper.tsx
@@ -5,6 +5,7 @@ export interface IDefaultPage {
   onExitAnimationDone?: () => void;
   isVisible?: boolean;
   isLeft?: boolean | undefined;
+  animation: boolean;
 }
 
 interface IPageAnimationWrapper extends IDefaultPage, React.HTMLAttributes<HTMLDivElement> {}
@@ -13,10 +14,14 @@ export default function PageAnimationWrapper({
   isVisible = true,
   isLeft,
   children,
+  animation = false,
 }: IPageAnimationWrapper) {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!animation) {
+      return;
+    }
     const visibleAnimation = isLeft ? visibleLeftAnimation : visibleRightAnimation;
     const unvisibleAnimation = isLeft ? unvisibleLeftAnimation : unvisibleRightAnimation;
 


### PR DESCRIPTION
<!-- 제목 양식: `[태그(대문자)] #{task 작업 번호}: 작업 내용 요약`로 작성해주세요!! -->
<!-- 우측의 reviewers, assignees, labels, projects, milestone 등도 설정해주세요!! -->

<!-- 리뷰어가 코드의 문맥을 빠르게 파악할 수 있도록 PR의 내용에서 충분한 정보를 전달해주세요.-->

<!-- 체크 해주세요. -->

- [x] 버그 수정
- [ ] 기능 개발
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 기타... 설명:

## 📝 설명

첫 접속 페이지 애니메이션 제거

## ✨ 특이 사항

<!-- 리뷰어에게 특정 사항을 전달할 내용이 있다면 여기에 작성해주세요. -->
```tsx
// AnimatePrecense.tsx
  const isSamePage = childrenOfPreviousRender.current[0].key === validChildren[0].key;
  const animatePresence = !isSamePage;
```

전 페이지와 현재 페이지 키가 같으면 애니메이션 없음 ㅅㄱ


## 🖼️ 스크린샷 (선택 사항)

<!-- 변경 사항에 대한 스크린샷이 있다면 여기에 첨부해주세요. -->
