### PR TITLE
[BUX FIX] #265: API분리로 옵션의 default여부를 판단하여 상세정보 반환

### DIFF
--- a/backend/src/main/java/autoever2/cartag/controller/OptionController.java
+++ b/backend/src/main/java/autoever2/cartag/controller/OptionController.java
@@ -36,13 +36,22 @@ public class OptionController {
         return optionService.getSubOptionList(carId);
     }
 
-    @Operation(summary = "옵션 상세정보 조회", description = "옵션 데이터 상세정보 및 이미지, HMG가 존재한다면(비어있다면 비어있는 부분을 Null) 보냄")
+    @Operation(summary = "추가옵션 상세정보 조회", description = "추가옵션 데이터 상세정보 및 이미지, HMG가 존재한다면(비어있다면 비어있는 부분을 Null) 보냄")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = OptionDetailDto.class)))
     })
-    @GetMapping("/optiondetail")
-    public OptionDetailDto getOptionDetail(@Parameter(description = "차량 트림 ID") @RequestParam("carid") int carId, @Parameter(description = "옵션 ID") @RequestParam("optionid") int optionId) {
-        return optionService.getOptionDetailData(carId, optionId);
+    @GetMapping("/sub/detail")
+    public OptionDetailDto getSubOptionDetail(@Parameter(description = "차량 트림 ID") @RequestParam("carid") int carId, @Parameter(description = "옵션 ID") @RequestParam("optionid") int optionId) {
+        return optionService.getOptionDetailData(carId, optionId, false);
+    }
+
+    @Operation(summary = "기본옵션 상세정보 조회", description = "기본옵션 데이터 상세정보 및 이미지, HMG가 존재한다면(비어있다면 비어있는 부분을 Null) 보냄")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = OptionDetailDto.class)))
+    })
+    @GetMapping("/default/detail")
+    public OptionDetailDto getDefaultOptionDetail(@Parameter(description = "차량 트림 ID") @RequestParam("carid") int carId, @Parameter(description = "옵션 ID") @RequestParam("optionid") int optionId) {
+        return optionService.getOptionDetailData(carId, optionId, true);
     }
 
     @Operation(summary = "기본 옵션 리스트 조회", description = "기본 옵션 데이터와 및 HMG 데이터 존재 여부 List 제공")

--- a/backend/src/main/java/autoever2/cartag/service/OptionService.java
+++ b/backend/src/main/java/autoever2/cartag/service/OptionService.java
@@ -54,8 +54,8 @@ public class OptionService {
     }
 
     //TODO: RuntimeException 처리
-    public OptionDetailDto getOptionDetailData(int carId, int optionId) {
-        OptionDetailMappedDto detail = optionRepository.findOptionDetail(carId, optionId, false).orElseThrow(() -> new RuntimeException("데이터가 존재하지 않습니다."));
+    public OptionDetailDto getOptionDetailData(int carId, int optionId, boolean isDefault) {
+        OptionDetailMappedDto detail = optionRepository.findOptionDetail(carId, optionId, isDefault).orElseThrow(() -> new RuntimeException("데이터가 존재하지 않습니다."));
 
         List<OptionDetailMappedDto> packageSubOptions = optionRepository.findPackageSubOptions(optionId);
 

--- a/backend/src/test/java/autoever2/cartag/controller/OptionControllerTest.java
+++ b/backend/src/test/java/autoever2/cartag/controller/OptionControllerTest.java
@@ -154,8 +154,8 @@ class OptionControllerTest {
                 .subOptionList(subOptions)
                 .build();
 
-        given(optionService.getOptionDetailData(carId, optionWithHmg)).willReturn(expected1);
-        given(optionService.getOptionDetailData(carId, optionPackage)).willReturn(expected2);
+        given(optionService.getOptionDetailData(carId, optionWithHmg, false)).willReturn(expected1);
+        given(optionService.getOptionDetailData(carId, optionPackage, false)).willReturn(expected2);
 
         ResultActions singleOption = mockMvc.perform(MockMvcRequestBuilders.get("/api/options/optiondetail").param("carid", String.valueOf(carId)).param("optionid", String.valueOf(optionWithHmg)));
         ResultActions packageOption = mockMvc.perform(MockMvcRequestBuilders.get("/api/options/optiondetail").param("carid", String.valueOf(carId)).param("optionid", String.valueOf(optionPackage)));

--- a/backend/src/test/java/autoever2/cartag/service/OptionServiceTest.java
+++ b/backend/src/test/java/autoever2/cartag/service/OptionServiceTest.java
@@ -198,8 +198,8 @@ class OptionServiceTest {
         when(optionRepository.findPackageSubOptions(packageOption)).thenReturn(subPackages);
         when(carRepository.findCarBoughtCountByCarId(carId)).thenReturn(Optional.of(150000L));
 
-        OptionDetailDto singleResult = optionService.getOptionDetailData(carId, singleOption);
-        OptionDetailDto packageResult = optionService.getOptionDetailData(carId, packageOption);
+        OptionDetailDto singleResult = optionService.getOptionDetailData(carId, singleOption, false);
+        OptionDetailDto packageResult = optionService.getOptionDetailData(carId, packageOption, false);
 
         softAssertions.assertThat(singleResult).usingRecursiveComparison().isEqualTo(expected1);
         softAssertions.assertThat(packageResult).usingRecursiveComparison().isEqualTo(expected2);


### PR DESCRIPTION
<!-- 제목 양식: `[태그(대문자)] #{task 작업 번호}: 작업 내용 요약`로 작성해주세요!! -->
<!-- 우측의 reviewers, assignees, labels, projects, milestone 등도 설정해주세요!! -->

<!-- 리뷰어가 코드의 문맥을 빠르게 파악할 수 있도록 PR의 내용에서 충분한 정보를 전달해주세요.-->

<!-- 체크 해주세요. -->

- [X] 버그 수정
- [ ] 기능 개발
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 기타... 설명:

## 📝 설명
기본옵션의 상세 데이터가 반환되지 않는 오류를 해결하였음.

## ✨ 특이 사항
- close : #265 
<!-- 리뷰어에게 특정 사항을 전달할 내용이 있다면 여기에 작성해주세요. -->

## 🖼️ 스크린샷 (선택 사항)

<!-- 변경 사항에 대한 스크린샷이 있다면 여기에 첨부해주세요. -->
